### PR TITLE
Light CMO buffs

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -192,6 +192,15 @@
 		/obj/item/stack/sticky_tape //surgical tape
 		))
 
+/obj/item/storage/belt/medical/surgeryfilled/PopulateContents()
+	new /obj/item/healthanalyzer(src)
+	new /obj/item/scalpel(src)
+	new /obj/item/hemostat(src)
+	new /obj/item/retractor(src)
+	new /obj/item/circular_saw(src)
+	new /obj/item/cautery(src)
+	new /obj/item/surgical_drapes(src)
+
 /obj/item/storage/belt/medical/paramedic/PopulateContents()
 	new /obj/item/sensor_device(src)
 	new /obj/item/pinpointer/crew/prox(src)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -193,7 +193,6 @@
 		))
 
 /obj/item/storage/belt/medical/surgeryfilled/PopulateContents()
-	new /obj/item/healthanalyzer(src)
 	new /obj/item/scalpel(src)
 	new /obj/item/hemostat(src)
 	new /obj/item/retractor(src)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -192,7 +192,7 @@
 		/obj/item/stack/sticky_tape //surgical tape
 		))
 
-/obj/item/storage/belt/medical/surgeryfilled/PopulateContents()
+/obj/item/storage/belt/medical/surgeryfilled/PopulateContents() // Tegu edit
 	new /obj/item/scalpel(src)
 	new /obj/item/hemostat(src)
 	new /obj/item/retractor(src)

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -41,7 +41,6 @@
 	uniform = /obj/item/clothing/under/rank/medical/chief_medical_officer
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 	suit = /obj/item/clothing/suit/toggle/labcoat/cmo
-	gloves = /obj/item/clothing/gloves/color/latex/nitrile
 	l_hand = /obj/item/storage/firstaid/medical
 	suit_store = /obj/item/flashlight/pen/paramedic
 	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1, /obj/item/modular_computer/tablet/preset/advanced/command=1)

--- a/code/modules/jobs/job_types/chief_medical_officer.dm
+++ b/code/modules/jobs/job_types/chief_medical_officer.dm
@@ -33,12 +33,15 @@
 	jobtype = /datum/job/cmo
 
 	id = /obj/item/card/id/silver
-	belt = /obj/item/pda/heads/cmo
+	belt = /obj/item/storage/belt/medical/surgeryfilled
+	r_pocket = /obj/item/pda/heads/cmo
 	l_pocket = /obj/item/pinpointer/crew
 	ears = /obj/item/radio/headset/heads/cmo
+	glasses = /obj/item/clothing/glasses/sunglasses/chemical
 	uniform = /obj/item/clothing/under/rank/medical/chief_medical_officer
 	shoes = /obj/item/clothing/shoes/sneakers/brown
 	suit = /obj/item/clothing/suit/toggle/labcoat/cmo
+	gloves = /obj/item/clothing/gloves/color/latex/nitrile
 	l_hand = /obj/item/storage/firstaid/medical
 	suit_store = /obj/item/flashlight/pen/paramedic
 	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1, /obj/item/modular_computer/tablet/preset/advanced/command=1)


### PR DESCRIPTION
Added Belt, Sciglasses and Nitriles on roundstart

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This PR adds 3 more things to the CMO's Kit.

Science HUD Sunglasses
Filled Surgery Belt
Nitrile gloves

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The CMO is by far the weakest, as well as the most useless head of staff. While the CE gets a full set of T2 tools the CMO gets half a set of T1 tools.
While every other head of staff gets Flash protection in some way, shape or form, the CMO gets absolutely none, including the hardsuit.
This PR solves both of these minor, but annoying negatives, as well as adding the Sciglasses that their chemists use to their starting kit.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Science Hud sunglasses, Nitrile gloves and filled surgery belt to the CMO's opening kit
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
