### PR TITLE
adds strange seeds to the biogenerator

### DIFF
--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -66,6 +66,14 @@
 	build_path = /obj/item/food/monkeycube
 	category = list("initial","Food")
 
+/datum/design/strange_seeds
+	name = "Pack of Strange Seeds"
+	id = "random"
+	build_type = BIOGENERATOR
+	materials = list(/datum/material/biomass= 5000)
+	build_path = /obj/item/seeds/random
+	category = list("initial", "Food")
+
 /datum/design/ez_nut   //easy nut :)
 	name = "25u E-Z Nutrient"
 	id = "ez_nut"

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -66,7 +66,7 @@
 	build_path = /obj/item/food/monkeycube
 	category = list("initial","Food")
 
-/datum/design/strange_seeds
+/datum/design/strange_seeds // Tegu edit
 	name = "Pack of Strange Seeds"
 	id = "random"
 	build_type = BIOGENERATOR


### PR DESCRIPTION
## About The Pull Request

adds strange seeds to the biogenerator 5000 biogen points each, makes botanists actually use the biogenerator

## Why It's Good For The Game

each round you can only get 4 strange seeds if cargo isnt competent enough to restock the vendors, this adds strange seeds to the biogenerator, and makes botanists actually use it

## Changelog
:cl:
add: Adds strange seeds to the biogenerator