### PR TITLE
Adds 2 job-unique traitor items

### DIFF
--- a/ModularTegustation/tegu_traitor_code/tegu_traitor_items.dm
+++ b/ModularTegustation/tegu_traitor_code/tegu_traitor_items.dm
@@ -69,3 +69,102 @@
 	new /obj/item/radio/headset/syndicate/alt(src)
 	new /obj/item/clothing/gloves/combat(src) //1 TC?
 	new /obj/item/gun/ballistic/automatic/pistol(src) //7 TC
+
+// Advanced hypno-flash. For psychologists.
+/obj/item/assembly/flash/hypnotic/adv
+	desc = "A modified flash device, used to beam preprogrammed orders directly into the target's mind."
+	light_color = COLOR_RED_LIGHT
+	var/hypno_cooldown = 29 SECONDS // Big damn cooldown
+	var/hypno_cooldown_current
+	var/hypno_message // User can change it by alt-clicking the flash.
+
+/obj/item/assembly/flash/hypnotic/adv/flash_carbon(mob/living/carbon/M, mob/user, power = 15, targeted = TRUE, generic_message = FALSE)
+	if(!istype(M))
+		return
+	if(user)
+		log_combat(user, M, "[targeted? "hypno-flashed(targeted)" : "hypno-flashed(AOE)"]", src)
+	else //caused by emp/remote signal
+		M.log_message("was [targeted? "hypno-flashed(targeted)" : "hypno-flashed(AOE)"]",LOG_ATTACK)
+	if(generic_message && M != user)
+		to_chat(M, "<span class='notice'>[src] emits a red, sharp light!</span>")
+	if(targeted)
+		if(M.flash_act(1, 1))
+			if(user)
+				user.visible_message("<span class='danger'>[user] blinds [M] with the flash!</span>", "<span class='danger'>You hypno-flash [M]!</span>")
+
+			if(hypno_cooldown_current > world.time) // Still on cooldown
+				to_chat(M, "<span class='hypnophrase'>The light makes you feel oddly relaxed...</span>")
+				M.add_confusion(min(M.get_confusion() + 10, 20))
+				M.dizziness += min(M.dizziness + 10, 20)
+				M.drowsyness += min(M.drowsyness + 10, 20)
+				M.apply_status_effect(STATUS_EFFECT_PACIFY, 100)
+			else
+				if(!hypno_message) // Aka default settings
+					hypno_message = "You are a secret agent, working for [user.real_name]. \
+					You must do everything they order you and never attempt to harm, or let anyone else harm them."
+				hypno_cooldown_current = world.time + hypno_cooldown
+				M.apply_status_effect(STATUS_EFFECT_PACIFY, 30)
+				M.cure_trauma_type(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY) //clear previous hypnosis
+				addtimer(CALLBACK(M, /mob/living/carbon.proc/gain_trauma, /datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY, hypno_message), 10)
+				addtimer(CALLBACK(M, /mob/living.proc/Stun, 60, TRUE, TRUE), 15)
+
+
+		else if(user)
+			user.visible_message("<span class='warning'>[user] fails to blind [M] with the flash!</span>", "<span class='warning'>You fail to hypno-flash [M]!</span>")
+		else
+			to_chat(M, "<span class='danger'>[src] fails to blind you!</span>")
+
+	else if(M.flash_act())
+		to_chat(M, "<span class='notice'>Such a pretty light...</span>")
+		M.add_confusion(min(M.get_confusion() + 4, 20))
+		M.dizziness += min(M.dizziness + 4, 20)
+		M.drowsyness += min(M.drowsyness + 4, 20)
+		M.apply_status_effect(STATUS_EFFECT_PACIFY, 40)
+
+/obj/item/assembly/flash/hypnotic/adv/AltClick(mob/user)
+	hypno_message = stripped_input(user, "What order will be given to hypnotised people?", \
+	"You are a secret agent, working for [user.real_name]. You must do everything they order \
+	you and never attempt to harm, or let anyone else harm them.", "Hypnosis message")
+	to_chat(user, "<span class='notice'>New message is: [hypno_message]</span>")
+
+// Virology bottles
+/obj/item/reagent_containers/glass/bottle/accelerant_ts
+	name = "Fast transmitability virus accelerant"
+	desc = "A small bottle containing TCS-TSA strain."
+	spawned_disease = /datum/disease/advance/adv_ts
+
+/obj/item/reagent_containers/glass/bottle/accelerant_mp
+	name = "Multi-purpose virus accelerant"
+	desc = "A small bottle containing TCS-MPA strain."
+	spawned_disease = /datum/disease/advance/adv_mp
+
+/obj/item/reagent_containers/glass/bottle/accelerant_sr
+	name = "Resistant stealth virus accelerant"
+	desc = "A small bottle containing TCS-SRA strain."
+	spawned_disease = /datum/disease/advance/adv_sr
+
+/obj/item/reagent_containers/glass/bottle/fake_oxygen
+	name = "Self-Respiratory Detonator bottle"
+	desc = "A small bottle containing rare disease that tries to disguise as self-respiration strain."
+	spawned_disease = /datum/disease/advance/fake_oxygen
+
+// Syndi-kit
+/obj/item/storage/box/syndie_kit/virology
+	name = "virology kit"
+
+/obj/item/storage/box/syndie_kit/virology/ComponentInitialize()
+	. = ..()
+	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.max_items = 10
+
+/obj/item/storage/box/syndie_kit/virology/PopulateContents()
+	new /obj/item/reagent_containers/glass/bottle/accelerant_ts(src)
+	new /obj/item/reagent_containers/glass/bottle/accelerant_mp(src)
+	new /obj/item/reagent_containers/glass/bottle/accelerant_sr(src)
+	new /obj/item/reagent_containers/glass/bottle/fake_oxygen(src)
+	new /obj/item/reagent_containers/glass/bottle/formaldehyde(src)
+	new /obj/item/reagent_containers/glass/bottle/synaptizine(src)
+	new /obj/item/reagent_containers/glass/beaker/large(src)
+	new /obj/item/reagent_containers/glass/beaker/large(src)
+	new /obj/item/reagent_containers/dropper(src)
+	new /obj/item/reagent_containers/syringe(src)

--- a/ModularTegustation/tegu_traitor_code/tegu_traitor_items.dm
+++ b/ModularTegustation/tegu_traitor_code/tegu_traitor_items.dm
@@ -74,7 +74,7 @@
 /obj/item/assembly/flash/hypnotic/adv
 	desc = "A modified flash device, used to beam preprogrammed orders directly into the target's mind."
 	light_color = COLOR_RED_LIGHT
-	var/hypno_cooldown = 29 SECONDS // Big damn cooldown
+	var/hypno_cooldown = 59 SECONDS // Big damn cooldown
 	var/hypno_cooldown_current
 	var/hypno_message // User can change it by alt-clicking the flash.
 
@@ -101,7 +101,7 @@
 			else
 				if(!hypno_message) // Aka default settings
 					hypno_message = "You are a secret agent, working for [user.real_name]. \
-					You must do everything they order you and never attempt to harm, or let anyone else harm them."
+					You must do anything they ask of you, and you must never attempt to harm them, nor allow harm to come to them."
 				hypno_cooldown_current = world.time + hypno_cooldown
 				M.apply_status_effect(STATUS_EFFECT_PACIFY, 30)
 				M.cure_trauma_type(/datum/brain_trauma/hypnosis, TRAUMA_RESILIENCE_SURGERY) //clear previous hypnosis
@@ -123,8 +123,8 @@
 
 /obj/item/assembly/flash/hypnotic/adv/AltClick(mob/user)
 	hypno_message = stripped_input(user, "What order will be given to hypnotised people?", \
-	"You are a secret agent, working for [user.real_name]. You must do everything they order \
-	you and never attempt to harm, or let anyone else harm them.", "Hypnosis message")
+	"You are a secret agent, working for [user.real_name]. You must do anything they ask of you, \
+	and you must never attempt to harm them, nor allow harm to come to them.", "Hypnosis message")
 	to_chat(user, "<span class='notice'>New message is: [hypno_message]</span>")
 
 // Virology bottles

--- a/ModularTegustation/tegu_traitor_code/uplink_items_tegu.dm
+++ b/ModularTegustation/tegu_traitor_code/uplink_items_tegu.dm
@@ -7,6 +7,24 @@
 	restricted_roles = list("Curator")
 	limited_stock = 1 //for testing at least
 
+/datum/uplink_item/role_restricted/hypnotic_flash/psych
+	name = "Advanced Hypnotic Flash"
+	desc = "A modified flash able to hypnotize targets. This model is capable of beaming orders directly into target's mind, instantly. \
+			The only downside is that it requires about 30 seconds to recharge. Still doesn't work against mental barriers, such as mindshield implants."
+	item = /obj/item/assembly/flash/hypnotic/adv
+	cost = 10
+	cant_discount = FALSE
+	restricted_roles = list("Psychologist")
+	limited_stock = 1
+
+/datum/uplink_item/role_restricted/symptom_box
+	name = "Virology Symptoms Box"
+	desc = "Box full of advanced virology symptoms, extracted from Tiger Co. abandoned laborotories. \
+	Bottles range from simple accelerators to deadly diseases."
+	item = /obj/item/storage/box/syndie_kit/virology
+	cost = 12
+	cant_discount = FALSE
+	restricted_roles = list("Virologist")
 
 /datum/uplink_item/badass/balloongold
 	name = "Golden Syndicate Balloons"

--- a/ModularTegustation/tegu_traitor_code/uplink_items_tegu.dm
+++ b/ModularTegustation/tegu_traitor_code/uplink_items_tegu.dm
@@ -10,7 +10,8 @@
 /datum/uplink_item/role_restricted/hypnotic_flash/psych
 	name = "Advanced Hypnotic Flash"
 	desc = "A modified flash able to hypnotize targets. This model is capable of beaming orders directly into target's mind, instantly. \
-			The only downside is that it requires about 30 seconds to recharge. Still doesn't work against mental barriers, such as mindshield implants."
+			The only downside is that it requires about a minute to recharge. This one allows user to input a message straight into device, \
+			removing the need to say anything after using it on your target."
 	item = /obj/item/assembly/flash/hypnotic/adv
 	cost = 10
 	cant_discount = FALSE
@@ -20,7 +21,7 @@
 /datum/uplink_item/role_restricted/symptom_box
 	name = "Virology Symptoms Box"
 	desc = "Box full of advanced virology symptoms, extracted from Tiger Co. abandoned laborotories. \
-	Bottles range from simple accelerators to deadly diseases."
+	Strains range from virus accelerants to deadly diseases."
 	item = /obj/item/storage/box/syndie_kit/virology
 	cost = 12
 	cant_discount = FALSE

--- a/ModularTegustation/tegu_virology.dm
+++ b/ModularTegustation/tegu_virology.dm
@@ -1,0 +1,123 @@
+// Virology "advanced" symptoms.
+/datum/symptom/adv_transmit
+	name = "TCS-TSA 1" // Tiger Co Syndicate - Transmission Speed Accelerator
+	desc = "Some sort of a dark, rapidly developing bacteria; Although it makes presence of the virus very obvious, \
+	it rapidly transmits and evolves to the last stages almost instantly, possibly killing everything in the process."
+	stealth = -9
+	resistance = -5
+	stage_speed = 9
+	transmittable = 7
+	level = 19 // Can't get it normally
+
+/datum/symptom/adv_everything
+	name = "TCS-MPA 2" // Tiger Co Syndicate - Multi-Purpose Accelerator
+	desc = "A multi-purpose strain, capable of increasing most statistics of a virus by a small amount."
+	stealth = 3
+	resistance = 5
+	stage_speed = 5
+	transmittable = 3
+	level = 19
+
+/datum/symptom/adv_stealth
+	name = "TCS-SRA 3" // Tiger Co Syndicate - Stealth Resistance Accelerator
+	desc = "A rare symptom, previously unknown to Nanotrasen. \
+	This symptom makes virus near to impossible to spot, although hinders its ability to develop fast enough."
+	stealth = 7
+	resistance = 5
+	stage_speed = -9
+	transmittable = -5
+	level = 19
+
+/datum/symptom/fake_oxygen // Fake self-respiration, heals until stage 5, then begins to kill.
+	name = "Self-Respiratory Detonator"
+	desc = "Virus that resembles Self-Respiration symptom, up until the last stage where it begins to absord oxygen in victim's body."
+	stealth = 2
+	resistance = -1
+	stage_speed = -2
+	transmittable = 0
+	level = 19
+	base_message_chance = 5
+	symptom_delay_min = 1
+	symptom_delay_max = 2
+	var/regenerate_blood = FALSE
+	threshold_descs = list(
+		"Resistance 8" = "Regenerates blood. At the last stage it will ignore body safety thresholds."
+	)
+
+/datum/symptom/fake_oxygen/Start(datum/disease/advance/A)
+	if(!..())
+		return
+	if(A.properties["resistance"] >= 8) //blood "regeneration"
+		regenerate_blood = TRUE
+
+/datum/symptom/fake_oxygen/Activate(datum/disease/advance/A)
+	if(!..())
+		return
+	var/mob/living/carbon/M = A.affected_mob
+	switch(A.stage)
+		if(5)
+			M.adjustOxyLoss(4, 0)
+			M.losebreath += 2
+			if(prob(20))
+				M.emote("gasp")
+			if(prob(base_message_chance))
+				to_chat(M, "<span class='userwarning'>[pick("You feel a dull pain in your chest.", "You try to breathe, but can't inhale air!", "Your lungs feel empty!")]</span>")
+			if(regenerate_blood && M.blood_volume < BLOOD_VOLUME_MAX_LETHAL) // It won't really kill you, but you will feel bad.
+				M.blood_volume += 2
+		if(3, 4)
+			M.adjustOxyLoss(-7, 0)
+			M.losebreath = max(0, M.losebreath - 4)
+			if(regenerate_blood && M.blood_volume < BLOOD_VOLUME_NORMAL)
+				M.blood_volume += 1
+		if(1, 2)
+			if(prob(base_message_chance))
+				to_chat(M, "<span class='notice'>[pick("Your lungs feel great.", "You realize you haven't been breathing.", "You don't feel the need to breathe.")]</span>")
+	return
+
+/datum/symptom/fake_oxygen/on_stage_change(datum/disease/advance/A)
+	if(!..())
+		return FALSE
+	var/mob/living/carbon/M = A.affected_mob
+	if(A.stage >= 3 && A.stage < 5) // Third and fourth stage.
+		ADD_TRAIT(M, TRAIT_NOBREATH, DISEASE_TRAIT)
+	else
+		REMOVE_TRAIT(M, TRAIT_NOBREATH, DISEASE_TRAIT)
+	return TRUE
+
+/datum/symptom/fake_oxygen/End(datum/disease/advance/A)
+	if(!..())
+		return
+	REMOVE_TRAIT(A.affected_mob, TRAIT_NOBREATH, DISEASE_TRAIT)
+
+
+// "Diseases" for bottles.
+//TS
+/datum/disease/advance/adv_ts
+	copy_type = /datum/disease/advance
+
+/datum/disease/advance/adv_ts/New()
+	symptoms = list(new/datum/symptom/adv_transmit)
+	..()
+
+//MP
+/datum/disease/advance/adv_mp
+	copy_type = /datum/disease/advance
+
+/datum/disease/advance/adv_mp/New()
+	symptoms = list(new/datum/symptom/adv_everything)
+	..()
+
+//SR
+/datum/disease/advance/adv_sr
+	copy_type = /datum/disease/advance
+
+/datum/disease/advance/adv_sr/New()
+	symptoms = list(new/datum/symptom/adv_stealth)
+	..()
+
+/datum/disease/advance/fake_oxygen
+	copy_type = /datum/disease/advance
+
+/datum/disease/advance/fake_oxygen/New()
+	symptoms = list(new/datum/symptom/fake_oxygen)
+	..()

--- a/ModularTegustation/tegu_virology.dm
+++ b/ModularTegustation/tegu_virology.dm
@@ -1,40 +1,40 @@
 // Virology "advanced" symptoms.
 /datum/symptom/adv_transmit
-	name = "TCS-TSA 1" // Tiger Co Syndicate - Transmission Speed Accelerator
+	name = "TCS-TSA 1" // Tiger Co Syndicate - Transmission Speed Accelerant
 	desc = "Some sort of a dark, rapidly developing bacteria; Although it makes presence of the virus very obvious, \
 	it rapidly transmits and evolves to the last stages almost instantly, possibly killing everything in the process."
 	stealth = -9
 	resistance = -5
-	stage_speed = 9
-	transmittable = 7
+	stage_speed = 8
+	transmittable = 6
 	level = 19 // Can't get it normally
 
 /datum/symptom/adv_everything
-	name = "TCS-MPA 2" // Tiger Co Syndicate - Multi-Purpose Accelerator
+	name = "TCS-MPA 2" // Tiger Co Syndicate - Multi-Purpose Accelerant
 	desc = "A multi-purpose strain, capable of increasing most statistics of a virus by a small amount."
 	stealth = 3
-	resistance = 5
-	stage_speed = 5
+	resistance = 4
+	stage_speed = 3
 	transmittable = 3
 	level = 19
 
 /datum/symptom/adv_stealth
-	name = "TCS-SRA 3" // Tiger Co Syndicate - Stealth Resistance Accelerator
+	name = "TCS-SRA 3" // Tiger Co Syndicate - Stealth Resistance Accelerant
 	desc = "A rare symptom, previously unknown to Nanotrasen. \
 	This symptom makes virus near to impossible to spot, although hinders its ability to develop fast enough."
 	stealth = 7
 	resistance = 5
 	stage_speed = -9
-	transmittable = -5
+	transmittable = -4
 	level = 19
 
 /datum/symptom/fake_oxygen // Fake self-respiration, heals until stage 5, then begins to kill.
 	name = "Self-Respiratory Detonator"
 	desc = "Virus that resembles Self-Respiration symptom, up until the last stage where it begins to absord oxygen in victim's body."
 	stealth = 2
-	resistance = -1
-	stage_speed = -2
-	transmittable = 0
+	resistance = -3
+	stage_speed = -3
+	transmittable = -4
 	level = 19
 	base_message_chance = 5
 	symptom_delay_min = 1
@@ -56,7 +56,7 @@
 	var/mob/living/carbon/M = A.affected_mob
 	switch(A.stage)
 		if(5)
-			M.adjustOxyLoss(4, 0)
+			M.adjustOxyLoss(5, 0)
 			M.losebreath += 2
 			if(prob(20))
 				M.emote("gasp")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3322,6 +3322,7 @@
 #include "ModularTegustation\tegu_procs.dm"
 #include "ModularTegustation\tegu_spaceruins.dm"
 #include "ModularTegustation\tegu_starfury_event.dm"
+#include "ModularTegustation\tegu_virology.dm"
 #include "ModularTegustation\tegu_world.dm"
 #include "ModularTegustation\tegu_beefmen\code\_DEFINES\beefman_defines.dm"
 #include "ModularTegustation\tegu_beefmen\code\modules\language\russian.dm"


### PR DESCRIPTION
## About The Pull Request

**WORK IN PROGRESS**

Adds instant hypnosis flash for Psychologist traitors. As it was said - it is instant, doesn't require the target to be asleep and so on, but flash has 30 seconds cooldown between each hypnosis.

Adds "advanced symptoms" kit for Virologist traitors, allowing their viruses to be an absolute terror.

## Why It's Good For The Game

Makes it so each traitor is unique in one way or another, allowing specific jobs to access some sort of gimmick, related to their job.

## Changelog
:cl:
add: Added instant hypnosis flash for Psychologist traitors.
add: Added "advanced symptoms" kit for Virologist traitors.
/:cl: