### PR TITLE
Adds a space exploration kit to mining voucher.

### DIFF
--- a/ModularTegustation/README.md
+++ b/ModularTegustation/README.md
@@ -137,3 +137,4 @@ Codewords to search PRs by:
 // Tegustation T5 parts - T5 parts
 // Tegustation Clothing - Vending machine clothes
 // Tegustation Heads of Staff - Heads of staff eguns
+// Tegustation Space Exploration - Stuff for space explorers/miners edits.

--- a/ModularTegustation/tegu_space_explorers.dm
+++ b/ModularTegustation/tegu_space_explorers.dm
@@ -4,7 +4,7 @@
 	icon_state = "duffel-explorer"
 	inhand_icon_state = "duffel-explorer"
 
-/obj/item/storage/backpack/duffelbag/mining_conscript/PopulateContents()
+/obj/item/storage/backpack/duffelbag/space_exploration/PopulateContents()
 	new /obj/item/clothing/suit/space/hardsuit/mining/compact(src)
 	new /obj/item/tank/jetpack/oxygen/harness(src)
 	new /obj/item/tank/internals/oxygen(src)

--- a/ModularTegustation/tegu_space_explorers.dm
+++ b/ModularTegustation/tegu_space_explorers.dm
@@ -1,0 +1,23 @@
+/obj/item/storage/backpack/duffelbag/space_exploration
+	name = "space exploration kit"
+	desc = "A kit containing everything a miner needs to qualify for space exploration."
+	icon_state = "duffel-explorer"
+	inhand_icon_state = "duffel-explorer"
+
+/obj/item/storage/backpack/duffelbag/mining_conscript/PopulateContents()
+	new /obj/item/clothing/suit/space/hardsuit/mining/compact(src)
+	new /obj/item/tank/jetpack/oxygen/harness(src)
+	new /obj/item/tank/internals/oxygen(src)
+	new /obj/item/binoculars(src)
+	new /obj/item/gps/mining(src)
+
+/obj/item/clothing/suit/space/hardsuit/mining/compact
+	name = "compact mining hardsuit"
+	desc = "A special suit that protects against hazardous, low pressure environments. Although similar to normal mining harsduit, this one seems to be a bit weaker."
+	w_class = WEIGHT_CLASS_NORMAL
+	armor = list(MELEE = 25, BULLET = 5, LASER = 10, ENERGY = 15, BOMB = 50, BIO = 100, RAD = 40, FIRE = 30, ACID = 75, WOUND = 5)
+	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/mining/compact
+
+/obj/item/clothing/head/helmet/space/hardsuit/mining/compact
+	name = "compact mining hardsuit helmet"
+	armor = list(MELEE = 25, BULLET = 5, LASER = 10, ENERGY = 15, BOMB = 50, BIO = 100, RAD = 40, FIRE = 30, ACID = 75, WOUND = 5)

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -170,7 +170,7 @@
 	return ..()
 
 /obj/machinery/mineral/equipment_vendor/proc/RedeemVoucher(obj/item/mining_voucher/voucher, mob/redeemer)
-	var/items = list("Survival Capsule and Explorer's Webbing", "Resonator Kit", "Minebot Kit", "Extraction and Rescue Kit", "Crusher Kit", "Mining Conscription Kit")
+	var/items = list("Survival Capsule and Explorer's Webbing", "Resonator Kit", "Minebot Kit", "Extraction and Rescue Kit", "Crusher Kit", "Mining Conscription Kit", "Space Exploration Kit") // Tegustation Space Exploration
 
 	var/selection = input(redeemer, "Pick your equipment", "Mining Voucher Redemption") as null|anything in sortList(items)
 	if(!selection || !Adjacent(redeemer) || QDELETED(voucher) || voucher.loc != redeemer)
@@ -196,6 +196,8 @@
 			new /obj/item/kinetic_crusher(drop_location)
 		if("Mining Conscription Kit")
 			new /obj/item/storage/backpack/duffelbag/mining_conscript(drop_location)
+		if("Space Exploration Kit") // Tegustation Space Exploration
+			new /obj/item/storage/backpack/duffelbag/space_exploration(drop_location)
 
 	SSblackbox.record_feedback("tally", "mining_voucher_redeemed", 1, selection)
 	qdel(voucher)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3357,6 +3357,7 @@
 #include "ModularTegustation\tegu_locker_overwrites.dm"
 #include "ModularTegustation\tegu_posters.dm"
 #include "ModularTegustation\tegu_procs.dm"
+#include "ModularTegustation\tegu_space_explorers.dm"
 #include "ModularTegustation\tegu_spaceruins.dm"
 #include "ModularTegustation\tegu_starfury_event.dm"
 #include "ModularTegustation\tegu_virology.dm"


### PR DESCRIPTION
## About The Pull Request

Adds a space exploration kit to mining voucher. That's it.

It consists of light-weight hardsuit(less armour), gps, oxygen tank and harness jetpack.

## Why It's Good For The Game

Allows miners to take on the exploration job early into the round.
I'd prefer adding a new job, but it would certainly fuck up any future /tg/ merges.

## Changelog
:cl:
add: Added space exploration kit to mining voucher.
/:cl: