### PR TITLE
Fixes xenobiology cargo exports.

### DIFF
--- a/ModularTegustation/tegu_cargo.dm
+++ b/ModularTegustation/tegu_cargo.dm
@@ -4,3 +4,4 @@
 		var/obj/item/slime_extract/slimething = O
 		if (slimething.sparkly == TRUE)
 			return costfromparent*2
+	return costfromparent


### PR DESCRIPTION
## About The Pull Request

As of now, due to black xenobio crossbreeds code, only sparkly cores would sell for something.
This fixes it.

## Why It's Good For The Game

It's a bug-fix.

## Changelog
:cl:
fix: Fixed slime core exports.
/:cl: