### PR TITLE
Updates alt title for Captain and (probably) fixes crew manifest.

### DIFF
--- a/code/datums/datacore.dm
+++ b/code/datums/datacore.dm
@@ -163,10 +163,11 @@
 	for(var/datum/data/record/t in GLOB.data_core.general)
 		var/name = t.fields["name"]
 		var/rank = t.fields["rank"]
+		var/true_rank = t.fields["truerank"]
 		var/has_department = FALSE
 		for(var/department in departments)
 			var/list/jobs = departments[department]
-			if(rank in jobs || (t.fields["truerank"] && (t.fields["truerank"] in jobs))) //Tegu edit - alt job titles
+			if((rank in jobs) || (true_rank in jobs)) //Tegu edit - alt job titles
 				if(!manifest_out[department])
 					manifest_out[department] = list()
 				manifest_out[department] += list(list(
@@ -230,8 +231,8 @@
 			assignment = "Unassigned"
 
 		//Tegu edit - Alt job titles
+		trueassignment = assignment
 		if(C && C.prefs && C.prefs.alt_titles_preferences[assignment])
-			trueassignment = assignment
 			assignment = C.prefs.alt_titles_preferences[assignment]
 		//Tegu edit end
 

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1178,10 +1178,10 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				var/datum/job/J = SSjob.GetJob(job_title)
 				var/sen_timelock = CONFIG_GET(number/senior_timelock)
 				var/ulsen_timelock = CONFIG_GET(number/ultra_senior_timelock)
-				if(user.client.prefs.exp[job_title] > (J.get_exp_req_amount() + sen_timelock)) //If they have more than 50 hours (300 Minutes) past the required time needed for the job, give them access to the senior title
+				if(user.client.prefs.exp[job_title] >= sen_timelock) //If they have more than 50 hours (300 Minutes) past the required time needed for the job, give them access to the senior title
 					if(J.senior_title)
 						titles_list += J.senior_title
-				if(user.client.prefs.exp[job_title] > (J.get_exp_req_amount() + ulsen_timelock)) //Ultra important(no) job title. Need more than 500 hours to unlock.
+				if(user.client.prefs.exp[job_title] >= ulsen_timelock) //Ultra important(no) job title. Need more than 500 hours to unlock.
 					if(J.ultra_senior_title)
 						titles_list += J.ultra_senior_title
 				for(var/i in J.alt_titles)

--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -29,7 +29,10 @@
 
 /datum/job/captain/announce(mob/living/carbon/human/H)
 	..()
-	SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, .proc/minor_announce, "Captain [H.real_name] on deck!"))
+	var/displayed_rank = H.mind.assigned_role // Tegu Edit: Alt Titles
+	if(H.client && H.client.prefs && H.client.prefs.alt_titles_preferences[H.mind.assigned_role])
+		displayed_rank = H.client.prefs.alt_titles_preferences[H.mind.assigned_role]
+	SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, .proc/minor_announce, "[displayed_rank] [H.real_name] on deck!")) // Tegu Edit: Alt Titles end
 
 /datum/outfit/job/captain
 	name = "Captain"

--- a/config/config.txt
+++ b/config/config.txt
@@ -409,12 +409,12 @@ AUTOADMIN_RANK Game Master
 #AUTO_DEADMIN_PLAYERS
 
 ## Uncomment to automatically deadmin antagonists when they gain the role.
-AUTO_DEADMIN_ANTAGONISTS
+#AUTO_DEADMIN_ANTAGONISTS
 
 ## Uncomment to automatically deadmin specific role sets when a player joins the game.
-AUTO_DEADMIN_HEADS
-AUTO_DEADMIN_SECURITY
-AUTO_DEADMIN_SILICONS
+#AUTO_DEADMIN_HEADS
+#AUTO_DEADMIN_SECURITY
+#AUTO_DEADMIN_SILICONS
 
 
 ## CLIENT VERSION CONTROL
@@ -543,7 +543,7 @@ DEFAULT_VIEW_SQUARE 15x15
 #DISCORD_ROLEID 000000000000000000
 
 ##Amount of time required for senior job titles in minutes
-SENIOR_TIMELOCK 3000
+SENIOR_TIMELOCK 600
 
 ##Amount of time required for ULTRA senior job titles in minutes
-SENIOR_TIMELOCK 30000
+ULTRA_SENIOR_TIMELOCK 6000


### PR DESCRIPTION
## About The Pull Request

Apparently crew manifest was showing alt title'd jobs in "Misc" category, this PR supposedly fixes it.

Now the message "Captain [name] on deck!" will change depending on the alt title of the captain.

## Why It's Good For The Game

1. Bug fix.
2. Let players know, how experienced is the Captain.
