### PR TITLE
late april fools prank - makes lizard people smol

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -82,6 +82,7 @@
 /datum/species/lizard/on_species_gain(mob/living/carbon/C, datum/species/old_species, pref_load)
 	var/real_tail_type = C.dna.features["tail_lizard"]
 	var/real_spines = C.dna.features["spines"]
+	C.dna.add_mutation(DWARFISM)
 
 	. = ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

gives lizardmen the dwarfism mutation as a late aprilfools prank

## Why It's Good For The Game

they look funny

![](https://user-images.githubusercontent.com/27740099/95035012-de4b7600-0680-11eb-81db-11be5636a6ab.png)

## Changelog
:cl:
add: makes lizardmen smol
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
