### PR TITLE
Small tribal rebalance

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -177,6 +177,9 @@
 /area/ruin/unpowered/ash_walkers)
 "aC" = (
 /obj/structure/stone_tile/block/cracked,
+/obj/item/storage/belt/utility{
+	pixel_y = -6
+	},
 /obj/item/storage/toolbox/syndicate,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
@@ -606,7 +609,7 @@
 	dir = 8
 	},
 /obj/item/stack/sheet/sinew{
-	amount = 5
+	amount = 4
 	},
 /obj/item/stack/sheet/bone{
 	amount = 5
@@ -704,7 +707,7 @@
 /area/lavaland/surface/outdoors)
 "bP" = (
 /obj/structure/stone_tile/block,
-/obj/item/spear,
+/obj/item/spear/bonespear,
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -876,10 +879,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "ck" = (
-/obj/item/spear,
 /obj/structure/stone_tile{
 	dir = 4
 	},
+/obj/item/spear/bonespear,
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -890,7 +893,7 @@
 /obj/structure/stone_tile/cracked{
 	dir = 8
 	},
-/obj/item/spear,
+/obj/item/spear/bonespear,
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -994,7 +997,7 @@
 /obj/structure/stone_tile/cracked{
 	dir = 1
 	},
-/obj/item/spear,
+/obj/item/spear/bonespear,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "cA" = (
@@ -1037,8 +1040,8 @@
 	dir = 1
 	},
 /obj/structure/table/wood,
-/obj/item/spear,
-/obj/item/storage/belt,
+/obj/item/spear/bonespear,
+/obj/item/storage/belt/mining/primitive,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "cI" = (
@@ -1080,7 +1083,7 @@
 	dir = 4
 	},
 /obj/structure/table/wood,
-/obj/item/spear,
+/obj/item/spear/bonespear,
 /obj/item/scythe,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
@@ -1093,7 +1096,7 @@
 	dir = 8
 	},
 /obj/structure/table/wood,
-/obj/item/spear,
+/obj/item/spear/bonespear,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "cN" = (
@@ -1108,11 +1111,16 @@
 	dir = 4
 	},
 /obj/structure/table/wood,
-/obj/item/spear/bonespear,
 /obj/item/clothing/suit/hooded/cloak/goliath{
-	armor = list("melee" = 45, "bullet" = 10, "laser" = 25, "energy" = 35, "bomb" = 45, "bio" = 0, "rad" = 0, "fire" = 70, "acid" = 60);
+	armor = list("melee" = 40, "bullet" = 10, "laser" = 25, "energy" = 35, "bomb" = 45, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 80);
 	desc = "An old cape made with goliath plates, rumored to be from the age of greater ashwalkers.";
 	name = "ancient goliath cloak"
+	},
+/obj/item/spear/bonespear,
+/obj/item/spear/bonespear,
+/obj/item/storage/backpack/satchel/explorer{
+	pixel_x = 4;
+	pixel_y = -4
 	},
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
@@ -1207,8 +1215,8 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "dg" = (
-/obj/structure/bonfire/dense,
 /obj/structure/stone_tile/center,
+/obj/structure/bonfire/dense,
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)

--- a/code/datums/components/crafting/recipes.dm
+++ b/code/datums/components/crafting/recipes.dm
@@ -807,9 +807,10 @@
 /datum/crafting_recipe/heavybonearmor
 	name = "Heavy Bone Armor"
 	result = /obj/item/clothing/suit/hooded/cloak/bone
-	time = 60
-	reqs = list(/obj/item/stack/sheet/bone = 8,
-				/obj/item/stack/sheet/sinew = 3)
+	time = 80
+	reqs = list(/obj/item/stack/sheet/bone = 10,
+				/obj/item/stack/sheet/sinew = 3,
+				/obj/item/stack/sheet/animalhide/goliath_hide = 2)
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/bonetalisman

--- a/code/modules/clothing/suits/cloaks.dm
+++ b/code/modules/clothing/suits/cloaks.dm
@@ -54,17 +54,19 @@
 	icon_state = "goliath_cloak"
 	desc = "A staunch, practical cape made out of numerous monster materials, it is coveted amongst exiles & hermits."
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/pickaxe, /obj/item/spear, /obj/item/organ/regenerative_core/legion, /obj/item/kitchen/knife/combat/bone, /obj/item/kitchen/knife/combat/survival)
-	armor = list(MELEE = 35, BULLET = 10, LASER = 25, ENERGY = 35, BOMB = 25, BIO = 0, RAD = 0, FIRE = 60, ACID = 60) //a fair alternative to bone armor, requiring alternative materials and gaining a suit slot
+	armor = list(MELEE = 35, BULLET = 10, LASER = 25, ENERGY = 35, BOMB = 25, BIO = 0, RAD = 0, FIRE = 80, ACID = 60) //a fair alternative to bone armor, requiring alternative materials and gaining a suit slot
 	hoodtype = /obj/item/clothing/head/hooded/cloakhood/goliath
 	body_parts_covered = CHEST|GROIN|ARMS
+	resistance_flags = FIRE_PROOF
 
 /obj/item/clothing/head/hooded/cloakhood/goliath
 	name = "goliath cloak hood"
 	icon_state = "golhood"
 	desc = "A protective & concealing hood."
-	armor = list(MELEE = 35, BULLET = 10, LASER = 25, ENERGY = 35, BOMB = 25, BIO = 0, RAD = 0, FIRE = 60, ACID = 60)
+	armor = list(MELEE = 35, BULLET = 10, LASER = 25, ENERGY = 35, BOMB = 25, BIO = 0, RAD = 0, FIRE = 80, ACID = 60)
 	clothing_flags = SNUG_FIT
 	flags_inv = HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR
+	resistance_flags = FIRE_PROOF
 	transparent_protection = HIDEMASK
 
 /obj/item/clothing/suit/hooded/cloak/drake
@@ -91,25 +93,27 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 
 /obj/item/clothing/suit/hooded/cloak/bone
-	name = "Heavy bone armor"
+	name = "heavy bone armor"
 	icon_state = "hbonearmor"
+	blood_overlay_type = "armor"
 	desc = "A tribal armor plate, crafted from animal bone. A heavier variation of standard bone armor."
-	armor = list("melee" = 40, "bullet" = 25, "laser" = 30, "energy" = 30, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/resonator, /obj/item/mining_scanner, /obj/item/t_scanner/adv_mining_scanner, /obj/item/gun/ballistic, /obj/item/gun/energy, /obj/item/kitchen/knife, /obj/item/pickaxe, /obj/item/spear)
+	armor = list(MELEE = 40, BULLET = 30, LASER = 40, ENERGY = 40, BOMB = 40, BIO = 0, RAD = 0, FIRE = 50, ACID = 50, WOUND = 20)
 	hoodtype = /obj/item/clothing/head/hooded/cloakhood/bone
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
 	max_heat_protection_temperature = ARMOR_MAX_TEMP_PROTECT
-	resistance_flags = NONE
+	resistance_flags = FIRE_PROOF
 	transparent_protection = HIDEGLOVES|HIDESUITSTORAGE|HIDEJUMPSUIT|HIDESHOES
 
 /obj/item/clothing/head/hooded/cloakhood/bone
-	name = "bone helmet"
+	name = "heavy bone helmet"
 	icon_state = "hskull"
 	desc = "An intimidating tribal helmet, it doesn't look very comfortable."
-	armor = list("melee" = 35, "bullet" = 25, "laser" = 25, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
+	armor = list(MELEE = 40, BULLET = 30, LASER = 40, ENERGY = 40, BOMB = 40, BIO = 0, RAD = 0, FIRE = 50, ACID = 50, WOUND = 20)
 	heat_protection = HEAD
 	max_heat_protection_temperature = HELMET_MAX_TEMP_PROTECT
-	resistance_flags = NONE
+	resistance_flags = FIRE_PROOF
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
 	flags_cover = HEADCOVERSEYES
 


### PR DESCRIPTION
## About The Pull Request

Changes heavy bone armor's armor value, what items it can hold, and the recipe.

Improves goliath cloak fire armor to 80 from 60.

Replaces all the spears ashwalkers get round-start with bone variants, adds an empty toolbelt.

## Why It's Good For The Game

Previously, heavy bone armor wasn't much stronger than the normal, despite being harder to craft. This fixes it.

Although I did admit that recipe was harder, it wasn't symmetrical, since it crafted both, armor and the helmet.
Where normal bone armor + skull helmet required 10 bones, heavy bone armor required only 8. Now it's 10 as well, plus 2 goliath plates.

Bone weapons, from recent changes, are now great anti-fauna weapons. It'd be a shame not to give tribal weapons to the most known tribals in the game.