### PR TITLE
Makes stun baton check for armor.

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -381,6 +381,9 @@
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_SMALL
 	item_flags = NONE
+	stunarmor_penetration = 0.8 // Buffs heads of staff!
+	knockdown_time_carbon = (3 SECONDS)
+	cooldown = 25
 	force = 0
 	on = FALSE
 	on_sound = 'sound/weapons/batonextend.ogg'


### PR DESCRIPTION
## About The Pull Request

Makes security stun batons check for melee armor before applying stamina damage and knockdown.
Doesn't knockdown people if they have more than 70  melee armor.

Also, buffs telebatons a bit, just so heads of staff have something to protect themselves with.

## Why It's Good For The Game

Stun batons were always the bain of antags/greytiders/everyone simply because it was a 2 click win, regardless of who you are.

This PR makes it so stun batons are less powerful against armored targets while still being a useful item against unarmored greytiders.
