### PR TITLE
TGUI "Create Command Report"; Fake announcement item for traitors.

### DIFF
--- a/ModularTegustation/tegu_traitor_code/tegu_traitor_items.dm
+++ b/ModularTegustation/tegu_traitor_code/tegu_traitor_items.dm
@@ -232,3 +232,153 @@
 /obj/item/storage/box/hug/mad_clown/PopulateContents()
 	new /obj/item/clothing/mask/gas/mad_clown(src)
 	new /obj/item/staff/roadsign(src)
+
+/* Fake Announcement Items */
+/obj/item/item_announcer
+	name = "FK-\"Deception\" Announcement Device"
+	desc = "The FK-Deception Announcement Device allows an \
+		enterprising syndicate agent to send a \
+		faked message from a certain source."
+	icon = 'icons/obj/device.dmi'
+	icon_state = "locator"
+	w_class = WEIGHT_CLASS_SMALL
+	/// The amount of reports we can send before breaking.
+	var/uses = 1
+
+/obj/item/item_announcer/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>It has [uses] uses left.</span>"
+
+/// Deletes the item when it's used up.
+/obj/item/item_announcer/proc/break_item(mob/user)
+	to_chat(user, "<span class='notice'>The [src] breaks down into unrecognizable scrap and ash after being used.</span>")
+	var/obj/effect/decal/cleanable/ash/spawned_ash = new(drop_location())
+	spawned_ash.desc = "Ashes to ashes, dust to dust. There's a few pieces of scrap in this pile."
+	playsound(src, "sparks", 100, TRUE, 5)
+	var/datum/effect_system/spark_spread/s = new /datum/effect_system/spark_spread
+	s.set_up(5, 1, get_turf(src))
+	s.start()
+	qdel(src)
+
+/// User sends a preset false alarm.
+/obj/item/item_announcer/preset
+	/// The name of the fake event, so we don't have to init it.
+	var/fake_event_name = ""
+	/// What false alarm this item triggers.
+	var/fake_event = null
+
+/obj/item/item_announcer/preset/Initialize()
+	. = ..()
+	if(fake_event)
+		for(var/datum/round_event_control/init_event in SSevents.control)
+			if(ispath(fake_event, init_event.type))
+				fake_event = init_event
+				break
+
+/obj/item/item_announcer/preset/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>It causes a fake \"[fake_event_name]\" when used.</span>"
+
+/obj/item/item_announcer/preset/attack_self(mob/user)
+	. = ..()
+	if(trigger_announcement(user) && uses <= 0)
+		break_item(user)
+
+/obj/item/item_announcer/preset/proc/trigger_announcement(mob/user)
+	var/datum/round_event_control/falsealarm/triggered_event = new()
+	if(!fake_event)
+		return FALSE
+	triggered_event.forced_type = fake_event
+	triggered_event.runEvent(FALSE)
+	to_chat(user, "<span class='notice'>You press the [src], triggering a false alarm for [fake_event_name].</span>")
+	message_admins("[ADMIN_LOOKUPFLW(user)] has triggered a false alarm using a syndicate device: \"[fake_event_name]\".")
+	deadchat_broadcast("<span class='bold'>Someone has triggered a false alarm using a syndicate device!</span>")
+	log_game("[key_name(user)] has triggered a false alarm using a syndicate device: \"[fake_event_name]\".")
+	uses--
+
+	return TRUE
+
+/obj/item/item_announcer/preset/ion
+	fake_event_name = "Ion Storm"
+	fake_event = /datum/round_event_control/ion_storm
+
+/obj/item/item_announcer/preset/rad
+	fake_event_name = "Radiation Storm"
+	fake_event = /datum/round_event_control/radiation_storm
+
+/// Allows users to input a custom announcement message.
+/obj/item/item_announcer/input
+	/// The name of central command that will accompany our fake report.
+	var/fake_command_name = "God Hand"
+	/// The actual contents of the report we're going to send.
+	var/command_report_content
+	/// Whether the report is an announced report or a classified report.
+	var/announce_contents = TRUE
+
+/obj/item/item_announcer/input/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>It sends messages from \"[fake_command_name]\".</span>"
+
+/obj/item/item_announcer/input/ui_state(mob/user)
+	return GLOB.inventory_state
+
+/obj/item/item_announcer/input/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "FakeCommandReport")
+		ui.open()
+
+/obj/item/item_announcer/input/ui_data(mob/user)
+	var/list/data = list()
+	data["command_name"] = fake_command_name
+	data["command_report_content"] = command_report_content
+	data["announce_contents"] = announce_contents
+
+	return data
+
+/obj/item/item_announcer/input/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return
+
+	switch(action)
+		if("update_report_contents")
+			command_report_content = params["updated_contents"]
+		if("toggle_announce")
+			announce_contents = !announce_contents
+		if("submit_report")
+			if(!command_report_content)
+				to_chat(usr, "<span class='danger'>You can't send a report with no contents.</span>")
+				return
+			if(send_announcement(usr) && uses <= 0)
+				break_item(usr)
+				return
+
+	return TRUE
+
+/// Send our announcement from [user] and decrease the amount of uses.
+/obj/item/item_announcer/input/proc/send_announcement(mob/user)
+	/// Our current command name to swap back to after sending the report.
+	var/original_command_name = command_name()
+	change_command_name(fake_command_name)
+
+	if(announce_contents)
+		priority_announce(command_report_content, null, SSstation.announcer.get_rand_report_sound(), has_important_message = TRUE)
+	print_command_report(command_report_content, "[announce_contents ? "" : "Classified "][fake_command_name] Update", !announce_contents)
+
+	change_command_name(original_command_name)
+
+	to_chat(user, "<span class='notice'>You tap on the [src], sending a [announce_contents ? "" : "classified "]report from [fake_command_name].</span>")
+	message_admins("[ADMIN_LOOKUPFLW(user)] has sent a fake command report using a syndicate device: \"[command_report_content]\".")
+	deadchat_broadcast("<span class='bold'>Someone has sent a fake report using a syndicate device!</span>")
+	log_game("[key_name(user)] has sent a fake command report using a syndicate device: \"[command_report_content]\", sent from \"[fake_command_name]\".")
+	uses--
+
+	return TRUE
+
+/obj/item/item_announcer/input/syndicate
+	fake_command_name = "The Syndicate"
+	uses = 2
+
+/obj/item/item_announcer/input/centcom
+	fake_command_name = "Central Command"

--- a/ModularTegustation/tegu_traitor_code/uplink_items_tegu.dm
+++ b/ModularTegustation/tegu_traitor_code/uplink_items_tegu.dm
@@ -219,3 +219,43 @@
 	new /obj/item/toy/balloon/syndicate/gold(src)
 	new /obj/item/toy/balloon/syndicate/gold(src)
 	new /obj/item/toy/balloon/syndicate/gold(src)
+
+/* Announcements */
+
+/datum/uplink_item/announcement
+	category = "Announcements"
+	surplus = 2
+	cant_discount = TRUE
+
+/// -- Modular/additional uplink items --
+/datum/uplink_item/announcement/fake_ionstorm
+	name = "Fake Ion Storm Announcement"
+	desc = "Ai, state flaws. A beacon with one use that triggers a fake ion storm, \
+		sending the crew clammering to investigate their nearest silicon."
+	item = /obj/item/item_announcer/preset/ion
+	cost = 4
+
+/datum/uplink_item/announcement/fake_radstorm
+	name = "Fake Radiation Storm Announcement"
+	desc = "Radiation storm! Turn on emergency maint! \
+		A beacon with one use that triggers a fake radiation storm, \
+		causing mild panic and a mad dash for maintenance. \
+		Does not come with warm air."
+	item = /obj/item/item_announcer/preset/rad
+	cost = 5
+
+/datum/uplink_item/announcement/syndicate_announcement
+	name = "Syndicate Announcement"
+	desc = "Forgoing any semblance of stealth and security? Need to make yourself known? \
+		A beacon with two uses that sends reports directly from The Syndicate to the station, classified or announced."
+	item = /obj/item/item_announcer/input/syndicate
+	cost = 8
+
+/datum/uplink_item/announcement/cc_announcement
+	name = "\"Central Command\" Announcement"
+	desc = "Need some diplomatic immunity to go along side your infiltration? \
+		A beacon with one use that sends a fake report from \"Central Command\" \
+		written by yours truly (you!). This report can be classified \
+		or announced to everyone."
+	item = /obj/item/item_announcer/input/centcom
+	cost = 12

--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -98,7 +98,7 @@
 #define ANNOUNCER_ALIENS			"announcer_aliens"
 #define ANNOUNCER_ANIMES 			"announcer_animes"
 #define ANNOUNCER_GRANOMALIES 		"announcer_granomalies"
-#define ANNOUNCER_INTERCEPT 		"announcer_animes"
+#define ANNOUNCER_INTERCEPT 		"announcer_intercept"
 #define ANNOUNCER_IONSTORM 			"announcer_ionstorm"
 #define ANNOUNCER_METEORS			"announcer_meteors"
 #define ANNOUNCER_OUTBREAK5			"announcer_outbreak5"
@@ -110,3 +110,23 @@
 #define ANNOUNCER_SHUTTLEDOCK		"announcer_shuttledock"
 #define ANNOUNCER_SHUTTLERECALLED	"announcer_shuttlerecalled"
 #define ANNOUNCER_SPANOMALIES		"announcer_spanomalies"
+
+/// Global list of all of our announcer keys.
+GLOBAL_LIST_INIT(announcer_keys, list(
+	ANNOUNCER_AIMALF,
+	ANNOUNCER_ALIENS,
+	ANNOUNCER_ANIMES,
+	ANNOUNCER_GRANOMALIES,
+	ANNOUNCER_INTERCEPT,
+	ANNOUNCER_IONSTORM,
+	ANNOUNCER_METEORS,
+	ANNOUNCER_OUTBREAK5,
+	ANNOUNCER_OUTBREAK7,
+	ANNOUNCER_POWEROFF,
+	ANNOUNCER_POWERON,
+	ANNOUNCER_RADIATION,
+	ANNOUNCER_SHUTTLECALLED,
+	ANNOUNCER_SHUTTLEDOCK,
+	ANNOUNCER_SHUTTLERECALLED,
+	ANNOUNCER_SPANOMALIES,
+))

--- a/code/modules/admin/verbs/commandreport.dm
+++ b/code/modules/admin/verbs/commandreport.dm
@@ -1,0 +1,146 @@
+/// The default command report announcement sound.
+#define DEFAULT_ANNOUNCEMENT_SOUND "default_announcement"
+
+/// Preset central command names to chose from for centcom reports.
+#define CENTCOM_PRESET "Central Command"
+#define SYNDICATE_PRESET "The Syndicate"
+#define WIZARD_PRESET "The Wizard Federation"
+#define CUSTOM_PRESET "Custom Command Name"
+
+/// Verb to change the global command name.
+/client/proc/cmd_change_command_name()
+	set category = "Admin.Events"
+	set name = "Change Command Name"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	var/input = input(usr, "Please input a new name for Central Command.", "What?", "") as text|null
+	if(!input)
+		return
+	change_command_name(input)
+	message_admins("[key_name_admin(src)] has changed Central Command's name to [input]")
+	log_admin("[key_name(src)] has changed the Central Command name to: [input]")
+
+/// Verb to open the create command report window and send command reports.
+/client/proc/cmd_admin_create_centcom_report()
+	set category = "Admin.Events"
+	set name = "Create Command Report"
+
+	if(!check_rights(R_ADMIN))
+		return
+
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "Create Command Report") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+	var/datum/command_report_menu/tgui = new(usr)
+	tgui.ui_interact(usr)
+
+/// Datum for holding the TGUI window for command reports.
+/datum/command_report_menu
+	/// The mob using the UI.
+	var/mob/ui_user
+	/// The name of central command that will accompany our report
+	var/command_name = CENTCOM_PRESET
+	/// Whether we are using a custom name instead of a preset.
+	var/custom_name
+	/// The actual contents of the report we're going to send.
+	var/command_report_content
+	/// Whether the report's contents are announced.
+	var/announce_contents = TRUE
+	/// The sound that's going to accompany our message.
+	var/played_sound = DEFAULT_ANNOUNCEMENT_SOUND
+	/// A static list of preset names that can be chosen.
+	var/static/list/preset_names = list(CENTCOM_PRESET, SYNDICATE_PRESET, WIZARD_PRESET, CUSTOM_PRESET)
+
+/datum/command_report_menu/New(mob/user)
+	ui_user = user
+
+/datum/command_report_menu/ui_state(mob/user)
+	return GLOB.admin_state
+
+/datum/command_report_menu/ui_close()
+	qdel(src)
+
+/datum/command_report_menu/ui_interact(mob/user, datum/tgui/ui)
+	ui = SStgui.try_update_ui(user, src, ui)
+	if(!ui)
+		ui = new(user, src, "CommandReport")
+		ui.open()
+
+/datum/command_report_menu/ui_data(mob/user)
+	var/list/data = list()
+	data["command_name"] = command_name
+	data["custom_name"] = custom_name
+	data["command_report_content"] = command_report_content
+	data["announce_contents"] = announce_contents
+	data["played_sound"] = played_sound
+
+	return data
+
+/datum/command_report_menu/ui_static_data(mob/user)
+	var/list/data = list()
+	data["command_name_presets"] = preset_names
+	data["announcer_sounds"] = list(DEFAULT_ANNOUNCEMENT_SOUND) + GLOB.announcer_keys
+
+	return data
+
+/datum/command_report_menu/ui_act(action, list/params, datum/tgui/ui, datum/ui_state/state)
+	. = ..()
+	if(.)
+		return
+
+	switch(action)
+		if("update_command_name")
+			if(params["updated_name"] == CUSTOM_PRESET)
+				custom_name = TRUE
+			else if (params["updated_name"] in preset_names)
+				custom_name = FALSE
+
+			command_name = params["updated_name"]
+		if("update_report_contents")
+			command_report_content = params["updated_contents"]
+		if("set_report_sound")
+			played_sound = params["picked_sound"]
+		if("toggle_announce")
+			announce_contents = !announce_contents
+		if("submit_report")
+			if(!command_name)
+				to_chat(ui_user, "<span class='danger'>You can't send a report with no command name.</span>")
+				return
+			if(!command_report_content)
+				to_chat(ui_user, "<span class='danger'>You can't send a report with no contents.</span>")
+				return
+			send_announcement()
+
+	return TRUE
+
+/*
+ * The actual proc that sends the priority announcement and reports
+ *
+ * Uses the variables set by the user on our datum as the arguments for the report.
+ */
+/datum/command_report_menu/proc/send_announcement()
+	/// Our current command name to swap back to after sending the report.
+	var/original_command_name = command_name()
+	change_command_name(command_name)
+
+	/// The sound we're going to play on report.
+	var/report_sound = played_sound
+	if(played_sound == DEFAULT_ANNOUNCEMENT_SOUND)
+		report_sound = SSstation.announcer.get_rand_report_sound()
+
+	if(announce_contents)
+		priority_announce(command_report_content, null, report_sound, has_important_message = TRUE)
+	print_command_report(command_report_content, "[announce_contents ? "" : "Classified "][command_name] Update", !announce_contents)
+
+	change_command_name(original_command_name)
+
+	log_admin("[key_name(ui_user)] has created a command report: \"[command_report_content]\", sent from \"[command_name]\" with the sound \"[played_sound]\".")
+	message_admins("[key_name_admin(ui_user)] has created a command report, sent from \"[command_name]\" with the sound \"[played_sound]\"")
+
+
+#undef DEFAULT_ANNOUNCEMENT_SOUND
+
+#undef CENTCOM_PRESET
+#undef SYNDICATE_PRESET
+#undef WIZARD_PRESET
+#undef CUSTOM_PRESET

--- a/code/modules/admin/verbs/randomverbs.dm
+++ b/code/modules/admin/verbs/randomverbs.dm
@@ -545,46 +545,6 @@ Traitors and the like can also be revived with the previous role mostly intact.
 	admin_ticket_log(M, msg)
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Rejuvenate") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
-/client/proc/cmd_admin_create_centcom_report()
-	set category = "Admin.Events"
-	set name = "Create Command Report"
-
-	if(!check_rights(R_ADMIN))
-		return
-
-	var/input = input(usr, "Enter a Command Report. Ensure it makes sense IC. Command's name is currently set to [command_name()].", "What?", "") as message|null
-	if(!input)
-		return
-
-	var/confirm = alert(src, "Do you want to announce the contents of the report to the crew?", "Announce", "Yes", "No", "Cancel")
-	var/announce_command_report = TRUE
-	switch(confirm)
-		if("Yes")
-			priority_announce(input, null, SSstation.announcer.get_rand_report_sound(), has_important_message = TRUE)
-			announce_command_report = FALSE
-		if("Cancel")
-			return
-
-	print_command_report(input, "[announce_command_report ? "Classified " : ""][command_name()] Update", announce_command_report)
-
-	log_admin("[key_name(src)] has created a command report: [input]")
-	message_admins("[key_name_admin(src)] has created a command report")
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "Create Command Report") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-/client/proc/cmd_change_command_name()
-	set category = "Admin.Events"
-	set name = "Change Command Name"
-
-	if(!check_rights(R_ADMIN))
-		return
-
-	var/input = input(usr, "Please input a new name for Central Command.", "What?", "") as text|null
-	if(!input)
-		return
-	change_command_name(input)
-	message_admins("[key_name_admin(src)] has changed Central Command's name to [input]")
-	log_admin("[key_name(src)] has changed the Central Command name to: [input]")
-
 /client/proc/cmd_admin_delete(atom/A as obj|mob|turf in world)
 	set category = "Debug"
 	set name = "Delete"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1481,6 +1481,7 @@
 #include "code\modules\admin\verbs\borgpanel.dm"
 #include "code\modules\admin\verbs\BrokenInhands.dm"
 #include "code\modules\admin\verbs\cinematic.dm"
+#include "code\modules\admin\verbs\commandreport.dm"
 #include "code\modules\admin\verbs\deadsay.dm"
 #include "code\modules\admin\verbs\debug.dm"
 #include "code\modules\admin\verbs\diagnostics.dm"

--- a/tgui/packages/tgui/interfaces/CommandReport.js
+++ b/tgui/packages/tgui/interfaces/CommandReport.js
@@ -1,0 +1,89 @@
+import { useBackend } from '../backend';
+import { Button, Dropdown, Input, Section, Stack, TextArea } from '../components';
+import { Window } from '../layouts';
+
+export const CommandReport = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    command_name,
+    custom_name,
+    command_name_presets = [],
+    command_report_content,
+    played_sound,
+    announcer_sounds = [],
+    announce_contents,
+  } = data;
+  return (
+    <Window
+      title="Create Command Report"
+      width={325}
+      height={525}>
+      <Window.Content>
+        <Stack vertical>
+          <Stack.Item>
+            <Section title="Set Central Command name:" textAlign="center">
+              <Dropdown
+                width="100%"
+                selected={command_name}
+                options={command_name_presets}
+                onSelected={value => act('update_command_name', {
+                  updated_name: value,
+                })} />
+              {!!custom_name && (
+                <Input
+                  width="100%"
+                  mt={1}
+                  value={command_name}
+                  placeholder={command_name}
+                  onChange={(e, value) => act("update_command_name", {
+                    updated_name: value,
+                  })} />
+              )}
+            </Section>
+          </Stack.Item>
+          <Stack.Item>
+            <Section title="Set announcement sound:" textAlign="center">
+              <Dropdown
+                width="100%"
+                displayText={played_sound}
+                options={announcer_sounds}
+                onSelected={value => act('set_report_sound', {
+                  picked_sound: value,
+                })} />
+            </Section>
+          </Stack.Item>
+          <Stack.Item>
+            <Section title="Set report text:" textAlign="center">
+              <TextArea
+                height="200px"
+                mb={1}
+                value={command_report_content}
+                onChange={(e, value) => act("update_report_contents", {
+                  updated_contents: value,
+                })} />
+              <Stack vertical>
+                <Stack.Item>
+                  <Button.Checkbox
+                    fluid
+                    checked={announce_contents}
+                    onClick={() => act("toggle_announce")}>
+                    Announce Contents
+                  </Button.Checkbox>
+                </Stack.Item>
+                <Stack.Item>
+                  <Button.Confirm
+                    fluid
+                    icon="check"
+                    color="good"
+                    textAlign="center"
+                    content="Submit Report"
+                    onClick={() => act("submit_report")} />
+                </Stack.Item>
+              </Stack>
+            </Section>
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};

--- a/tgui/packages/tgui/interfaces/FakeCommandReport.js
+++ b/tgui/packages/tgui/interfaces/FakeCommandReport.js
@@ -1,0 +1,62 @@
+import { useBackend } from '../backend';
+import { Button, Dropdown, Input, Section, Stack, TextArea } from '../components';
+import { Window } from '../layouts';
+
+export const FakeCommandReport = (props, context) => {
+  const { act, data } = useBackend(context);
+  const {
+    command_name,
+    command_report_content,
+    announce_contents,
+  } = data;
+  return (
+    <Window
+      title="Send Faked Command Report"
+      width={325}
+      height={425}
+      theme="syndicate">
+      <Window.Content>
+        <Stack vertical>
+          <Stack.Item>
+            <Section title="Central Command Name:" textAlign="center">
+              <Dropdown
+                width="100%"
+                selected={command_name}
+                disabled={1} />
+            </Section>
+          </Stack.Item>
+          <Stack.Item>
+            <Section title="Report Text:" textAlign="center">
+              <TextArea
+                height="200px"
+                mb={1}
+                value={command_report_content}
+                onChange={(e, value) => act("update_report_contents", {
+                  updated_contents: value,
+                })} />
+              <Stack vertical>
+                <Stack.Item>
+                  <Button.Checkbox
+                    fluid
+                    checked={announce_contents}
+                    onClick={() => act("toggle_announce")}>
+                    Announce Contents
+                  </Button.Checkbox>
+                </Stack.Item>
+                <Stack.Item>
+                  <Button.Confirm
+                    fluid
+                    icon="check"
+                    color="good"
+                    textAlign="center"
+                    content="Submit Fake Report"
+                    onClick={() => act("submit_report")} />
+                </Stack.Item>
+              </Stack>
+            </Section>
+          </Stack.Item>
+        </Stack>
+      </Window.Content>
+    </Window>
+  );
+};


### PR DESCRIPTION
## About The Pull Request

1. Ports #tgstation/tgstation/pull/58179
2. Ports #Jolly-66/JollyStation/pull/82

## Why It's Good For The Game

1. Admins don't have to suffer.
2. Traitors/Nuke ops now can do some big brain moves with fake announcements from CentCom. Or they can just go loud with the Syndicate announcement, which is, in my opinion, much better than breaking into Bridge to make a "Captain's" announcement from communications console.
